### PR TITLE
dispatch order change

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -54,16 +54,15 @@ export default function penderMiddleware(
 
     let cancelled = false;
 
-    // promise start
-    store.dispatch({
-      type: actions.PENDING,
-      meta,
-    });
-
     // inform pender reducer
     store.dispatch({
       type: PENDING,
       payload: type,
+    });
+    // promise start
+    store.dispatch({
+      type: actions.PENDING,
+      meta,
     });
 
     // use proxy to handle promise cancellation
@@ -111,16 +110,16 @@ export default function penderMiddleware(
         proxy.resolve = true;
         proxy = null;
 
+        // inform pender reducer
+        store.dispatch({
+          type: SUCCESS,
+          payload: type,
+        });
         // promise resolved
         store.dispatch({
           type: actions.SUCCESS,
           payload: result,
           meta,
-        });
-        // inform pender reducer
-        store.dispatch({
-          type: SUCCESS,
-          payload: type,
         });
       })
       .catch((e: Error) => {
@@ -129,17 +128,17 @@ export default function penderMiddleware(
         proxy.resolve = true;
         proxy = null;
 
+        // inform pender reducer
+        store.dispatch({
+          type: FAILURE,
+          payload: type,
+        });
         // promise rejected
         store.dispatch({
           type: actions.FAILURE,
           payload: e,
           error: true,
           meta,
-        });
-        // inform pender reducer
-        store.dispatch({
-          type: FAILURE,
-          payload: type,
         });
       });
 


### PR DESCRIPTION
Hello

When I call an action with pender, the pender state value was strange.
<img width="525" alt="스크린샷 2019-07-11 오후 3 04 50" src="https://user-images.githubusercontent.com/8206763/61026483-698e7b00-a3ee-11e9-8de5-b8c2efe745a2.png">

after onPending, there was no value in pender state value. 
also pender.success has false and pender.pending has true at the action.

Because of wrong dispatch ordering, the bug occurs.

So I updated.

After updated, the logs is following.

<img width="512" alt="스크린샷 2019-07-11 오후 3 06 18" src="https://user-images.githubusercontent.com/8206763/61026656-dc97f180-a3ee-11e9-8c9d-44bbbdd23756.png">

After onSuccess, the pender.success has true at the action and render is called.

Please check and feedback about that.
Thanks